### PR TITLE
Handled destroyed stream during while loop in data()

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (file, opts) {
   var bufferSize = opts && opts.bufferSize || 1024 * 64
   var mode = opts && opts.mode || 438 // 0666
   var flags = opts && opts.flags || 'r'
-  
+
   function onError (err) {
     stream.emit('error', err)
     stream.destroy()
@@ -54,8 +54,10 @@ module.exports = function (file, opts) {
       soFar = buffer + soFar
       var array = soFar.split(matcher)
       soFar = array.shift()
-      while(array.length) 
+      while(array.length) {
+        if(stream.destroyed) return
         stream.emit('data', array.pop())
+      }
     }
   })
 


### PR DESCRIPTION
This feature allows to destroy the readable stream if one is not interested in reading the whole file.
Of course could be handled in other ways, but now seems to be shorter and easier
`fsReverse(filePath).on("data", (chunk)=>{
    if (noMoreInterestedInFile){
      fileReader.destroy();
    }
    //do something
  });`