### PR TITLE
Avoid crash when file is missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function (file, opts) {
         if(!--c) read()
       })
       fs.open(file, flags, mode, function (err, _fd) {
+        if(err) return onError(err)
         fd = _fd
         stream.emit('open')
         if(!--c) read()


### PR DESCRIPTION
stream error Error: ENOENT: no such file or directory, stat 'some-missing-file.txt'
internal/validators.js:113
    throw err;
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "fd" argument must be of type number. Received type undefined
    at Object.close (fs.js:399:3)
    at Object.close (/server/node_modules/graceful-fs/graceful-fs.js:38:19)
    at Stream.close (/server/node_modules/fs-reverse/index.js:70:10)
    at Object.onceWrapper (events.js:276:13)
    at Stream.emit (events.js:188:13)
    at /server/node_modules/fs-reverse/index.js:32:16
    at FSReqCallback.args [as oncomplete] (fs.js:147:20)